### PR TITLE
Fix package imports and run generator script as standalone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ npm install test-data-management
 
 Using tdm in your project
 
-```
-import { TDM } from "tdm/tdm"
+```ts
+import { TDM } from "test-data-management"
 
 // Define these yourself
 import { users } from "./fixtures/users"

--- a/examples/github-issues/README.md
+++ b/examples/github-issues/README.md
@@ -10,23 +10,19 @@ permanently delete all existing Github issues in your repository!**
 ### Installation
 
 ```
-npm run tdm-build
+npm run build
 ```
 
 ### Running tdm
 
-Auto-generate bindings to the Github API
+Auto-generate bindings to the Github API and output to /schemas directory:
 
-_(From the root /tdm directory):_
 ```
-node dist/index.js generate openapi https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json examples/github-issues/schemas
+npx test-data-management generate openapi https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json schemas
 ```
 
-Run TDM in dry-run mode to see what changes will be applied
+Run TDM in dry-run mode to see what changes will be applied:
 
-_(From this directory):_
 ```
 node dist/index <github-api-key> <repo-organization> <repo-name> true
 ```
-
-Substitute the last argument for `false` to apply the changes.

--- a/examples/github-issues/package-lock.json
+++ b/examples/github-issues/package-lock.json
@@ -13,11 +13,43 @@
       },
       "devDependencies": {
         "octokit": "^1.7.1",
-        "tdm": "file:../../dist"
+        "test-data-management": "file:../.."
+      }
+    },
+    "../..": {
+      "name": "test-data-management",
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-progress": "^3.9.1",
+        "colors": "^1.4.0",
+        "commander": "^8.2.0",
+        "diff": "^5.0.0",
+        "jest": "^27.2.4",
+        "lodash": "^4.17.21",
+        "reflect-metadata": "^0.1.13",
+        "swagger-parser": "^10.0.3",
+        "utility-types": "^3.10.0"
+      },
+      "bin": {
+        "test-data-management": "dist/run.js"
+      },
+      "devDependencies": {
+        "@types/cli-progress": "^3.9.2",
+        "@types/diff": "^5.0.1",
+        "@types/jest": "^27.0.2",
+        "@types/lodash": "^4.14.175",
+        "@types/md5": "^2.3.1",
+        "@types/validator": "^13.6.4",
+        "md5": "^2.3.0",
+        "ts-jest": "^27.0.5",
+        "ts-morph": "^12.0.0",
+        "typescript": "^4.4.2"
       }
     },
     "../../dist": {
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@octokit/app": {
       "version": "12.0.5",
@@ -625,8 +657,8 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/tdm": {
-      "resolved": "../../dist",
+    "node_modules/test-data-management": {
+      "resolved": "../..",
       "link": true
     },
     "node_modules/tr46": {
@@ -1211,8 +1243,29 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
-    "tdm": {
-      "version": "file:../../dist"
+    "test-data-management": {
+      "version": "file:../..",
+      "requires": {
+        "@types/cli-progress": "^3.9.2",
+        "@types/diff": "^5.0.1",
+        "@types/jest": "^27.0.2",
+        "@types/lodash": "^4.14.175",
+        "@types/md5": "^2.3.1",
+        "@types/validator": "^13.6.4",
+        "cli-progress": "^3.9.1",
+        "colors": "^1.4.0",
+        "commander": "^8.2.0",
+        "diff": "^5.0.0",
+        "jest": "^27.2.4",
+        "lodash": "^4.17.21",
+        "md5": "^2.3.0",
+        "reflect-metadata": "^0.1.13",
+        "swagger-parser": "^10.0.3",
+        "ts-jest": "^27.0.5",
+        "ts-morph": "^12.0.0",
+        "typescript": "^4.4.2",
+        "utility-types": "^3.10.0"
+      }
     },
     "tr46": {
       "version": "0.0.3",

--- a/examples/github-issues/package.json
+++ b/examples/github-issues/package.json
@@ -3,15 +3,11 @@
   "version": "0.1.1",
   "license": "MIT",
   "scripts": {
-    "dev": "next",
-    "export": "next export",
-    "build": "next build",
-    "start": "next start",
-    "tdm-build": "tsc --project tsconfig.json"
+    "build": "tsc --project tsconfig.json"
   },
   "devDependencies": {
     "octokit": "^1.7.1",
-    "tdm": "file:../../dist"
+    "test-data-management": "file:../.."
   },
   "dependencies": {
     "axios": "^0.24.0"

--- a/examples/github-issues/tdm/fixtures/issue.ts
+++ b/examples/github-issues/tdm/fixtures/issue.ts
@@ -1,4 +1,4 @@
-import { Fixture, Relations } from "tdm/fixture";
+import { Fixture, Relations } from "test-data-management";
 import { IssueMapper } from "../issues/issue-mapper";
 import { Issue } from "../schemas/issue";
 

--- a/examples/github-issues/tdm/index.ts
+++ b/examples/github-issues/tdm/index.ts
@@ -1,4 +1,4 @@
-import { TDM } from "tdm/tdm"
+import { TDM } from "test-data-management
 import { issues } from "./fixtures/issue"
 import { IssueMapper } from "./issues/issue-mapper"
 import { IssueExecutor } from "./issues/issue-executor"

--- a/examples/github-issues/tdm/issues/issue-executor.ts
+++ b/examples/github-issues/tdm/issues/issue-executor.ts
@@ -1,4 +1,4 @@
-import { Executor } from "../../../../dist/executor"
+import { Executor } from "test-data-management"
 import { GithubApi } from "../api"
 import { Issue } from "../schemas/issue"
 

--- a/examples/github-issues/tdm/issues/issue-mapper.ts
+++ b/examples/github-issues/tdm/issues/issue-mapper.ts
@@ -1,5 +1,5 @@
 import { Issue } from "../schemas/issue"
-import { Mapper, Property } from "tdm/mapper"
+import { Mapper, Property } from "test-data-management"
 
 export class IssueMapper extends Mapper<Issue> {
   fields = {

--- a/examples/supabase-slack-clone/package-lock.json
+++ b/examples/supabase-slack-clone/package-lock.json
@@ -16,7 +16,7 @@
         "react-dom": "^16.7.0",
         "sass": "^1.26.2",
         "tailwindcss": "^1.1.4",
-        "tdm": "file:../../dist"
+        "test-data-management": "file:../.."
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^8.5.6",
@@ -25,15 +25,26 @@
       }
     },
     "../..": {
-      "version": "0.0.1",
+      "name": "test-data-management",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
+        "cli-progress": "^3.9.1",
+        "colors": "^1.4.0",
         "commander": "^8.2.0",
+        "diff": "^5.0.0",
         "jest": "^27.2.4",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13",
-        "swagger-parser": "^10.0.3"
+        "swagger-parser": "^10.0.3",
+        "utility-types": "^3.10.0"
+      },
+      "bin": {
+        "test-data-management": "dist/run.js"
       },
       "devDependencies": {
+        "@types/cli-progress": "^3.9.2",
+        "@types/diff": "^5.0.1",
         "@types/jest": "^27.0.2",
         "@types/lodash": "^4.14.175",
         "@types/md5": "^2.3.1",
@@ -44,7 +55,9 @@
         "typescript": "^4.4.2"
       }
     },
-    "../../dist": {},
+    "../../dist": {
+      "extraneous": true
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -3575,8 +3588,8 @@
         "node": ">=8"
       }
     },
-    "node_modules/tdm": {
-      "resolved": "../../dist",
+    "node_modules/test-data-management": {
+      "resolved": "../..",
       "link": true
     },
     "node_modules/timers-browserify": {
@@ -6517,8 +6530,29 @@
         }
       }
     },
-    "tdm": {
-      "version": "file:../../dist"
+    "test-data-management": {
+      "version": "file:../..",
+      "requires": {
+        "@types/cli-progress": "^3.9.2",
+        "@types/diff": "^5.0.1",
+        "@types/jest": "^27.0.2",
+        "@types/lodash": "^4.14.175",
+        "@types/md5": "^2.3.1",
+        "@types/validator": "^13.6.4",
+        "cli-progress": "^3.9.1",
+        "colors": "^1.4.0",
+        "commander": "^8.2.0",
+        "diff": "^5.0.0",
+        "jest": "^27.2.4",
+        "lodash": "^4.17.21",
+        "md5": "^2.3.0",
+        "reflect-metadata": "^0.1.13",
+        "swagger-parser": "^10.0.3",
+        "ts-jest": "^27.0.5",
+        "ts-morph": "^12.0.0",
+        "typescript": "^4.4.2",
+        "utility-types": "^3.10.0"
+      }
     },
     "timers-browserify": {
       "version": "2.0.12",

--- a/examples/supabase-slack-clone/package.json
+++ b/examples/supabase-slack-clone/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^16.7.0",
     "sass": "^1.26.2",
     "tailwindcss": "^1.1.4",
-    "tdm": "file:../../dist"
+    "test-data-management": "file:../.."
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.6",

--- a/examples/supabase-slack-clone/tdm/fixtures/channels.ts
+++ b/examples/supabase-slack-clone/tdm/fixtures/channels.ts
@@ -1,4 +1,4 @@
-import { Fixture, Relations } from 'tdm/fixture'
+import { Fixture, Relations } from 'test-data-management'
 import { ChannelMapper } from '../mappers/channels/channel-mapper'
 import { Channel } from '../schemas/channel'
 

--- a/examples/supabase-slack-clone/tdm/fixtures/messages.ts
+++ b/examples/supabase-slack-clone/tdm/fixtures/messages.ts
@@ -1,4 +1,4 @@
-import { Fixture, Relations } from 'tdm/fixture'
+import { Fixture, Relations } from 'test-data-management'
 import { MessageMapper } from '../mappers/messages/message-mapper'
 import { Message } from '../schemas/message'
 

--- a/examples/supabase-slack-clone/tdm/fixtures/users.ts
+++ b/examples/supabase-slack-clone/tdm/fixtures/users.ts
@@ -1,4 +1,4 @@
-import { Fixture, Relations } from 'tdm/fixture'
+import { Fixture, Relations } from 'test-data-management'
 import { UserMapper } from '../mappers/users/user-mapper'
 import { User } from '../schemas/user'
 

--- a/examples/supabase-slack-clone/tdm/index.ts
+++ b/examples/supabase-slack-clone/tdm/index.ts
@@ -1,4 +1,4 @@
-import { TDM } from "tdm/tdm"
+import { TDM } from "test-data-management"
 import { channels } from "./fixtures/channels"
 import { messages } from "./fixtures/messages"
 import { users } from "./fixtures/users"

--- a/examples/supabase-slack-clone/tdm/mappers/channels/channel-executor.ts
+++ b/examples/supabase-slack-clone/tdm/mappers/channels/channel-executor.ts
@@ -1,4 +1,4 @@
-import { Executor } from 'tdm/executor'
+import { Executor } from 'test-data-management'
 import { SupabaseApi } from "../api";
 import { Channel } from "../../schemas/channel";
 

--- a/examples/supabase-slack-clone/tdm/mappers/channels/channel-mapper.ts
+++ b/examples/supabase-slack-clone/tdm/mappers/channels/channel-mapper.ts
@@ -1,5 +1,5 @@
 import { Channel } from "../../schemas/channel";
-import { Mapper, Property } from "tdm/mapper";
+import { Mapper, Property } from "test-data-management";
 import { UserMapper } from "../users/user-mapper";
 
 export class ChannelMapper extends Mapper<Channel> {

--- a/examples/supabase-slack-clone/tdm/mappers/messages/message-executor.ts
+++ b/examples/supabase-slack-clone/tdm/mappers/messages/message-executor.ts
@@ -1,5 +1,5 @@
 import { Message } from "../../schemas/message";
-import { Executor } from 'tdm/executor'
+import { Executor } from 'test-data-management'
 import { SupabaseApi } from "../api";
 
 export class MessageExecutor extends Executor<Message> {

--- a/examples/supabase-slack-clone/tdm/mappers/messages/message-mapper.ts
+++ b/examples/supabase-slack-clone/tdm/mappers/messages/message-mapper.ts
@@ -1,5 +1,5 @@
 import { Message } from "../../schemas/message";
-import { Mapper, Property } from "tdm/mapper";
+import { Mapper, Property } from "test-data-management";
 import { UserMapper } from "../users/user-mapper";
 import { ChannelMapper } from "../channels/channel-mapper";
 

--- a/examples/supabase-slack-clone/tdm/mappers/users/user-executor.ts
+++ b/examples/supabase-slack-clone/tdm/mappers/users/user-executor.ts
@@ -1,4 +1,4 @@
-import { Executor } from 'tdm/executor'
+import { Executor } from 'test-data-management'
 import { SupabaseApi } from "../api";
 import { User } from '../../schemas/user';
 

--- a/examples/supabase-slack-clone/tdm/mappers/users/user-mapper.ts
+++ b/examples/supabase-slack-clone/tdm/mappers/users/user-mapper.ts
@@ -1,5 +1,5 @@
 import { User } from "../../schemas/user";
-import { Mapper, Property } from "tdm/mapper";
+import { Mapper, Property } from "test-data-management";
 
 export class UserMapper extends Mapper<User> {
   fields = {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "tdm (short for Test Data Management) is an open-source library to help you manage your test data. You can think of it as a Terraform for Test Data.",
     "scripts": {
-        "build": "tsc --project tsconfig.json",
+        "build": "tsc --build --clean && tsc --project tsconfig.json",
         "test": "jest"
     },
     "license": "MIT",
@@ -24,6 +24,10 @@
         "testing"
     ],
     "homepage": "https://github.com/runreflect/tdm#readme",
+    "bin": "dist/run.js",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "files": ["dist"],
     "dependencies": {
         "cli-progress": "^3.9.1",
         "colors": "^1.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,15 @@
+import { Executor } from './executor'
+import { Fixture, Relations } from './fixture'
+import { Property, Mapper, Relation } from './mapper'
+import { RunError, TDM } from './tdm'
+
+export {
+  Executor,
+  Fixture,
+  Mapper,
+  Property,
+  Relation,
+  Relations,
+  RunError,
+  TDM,
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { Command } from 'commander'
 import { OpenAPIGenerator } from './generators/open-api'
 


### PR DESCRIPTION
**Stop requiring imports from /dist directory and move generator to command on path**

- Updates package.json to use the /dist/index.js file as the main file for
the package.
- Adds typing in the NPM package
- Generator script can now be invoked via 'test-data-management <args>' if package
is installed globally or 'npx test-data-management <args>' if not.

**Move imports to index.js and update examples**

This moves all imports used by users of library to the dist/index.js
file which is now the main file in the NPM package. This will allow
users of the library to import TDM like this:

```
import { TDM } from 'test-data-management'
```
